### PR TITLE
Add fix in write_out() to fillna in neo4j CSV files

### DIFF
--- a/wd_to_neo4j.py
+++ b/wd_to_neo4j.py
@@ -70,14 +70,22 @@ class Bot:
         return s
 
     def write_out(self):
+        for line in self.edge_lines:
+          for key, value in line.items():
+            if type(value) is str and value == '':
+              line[key] = None
         df_edges = pd.DataFrame(self.edge_lines)
         df_edges['reference_date'] = None
         df_edges = df_edges[self.edge_columns]
-        df_edges.to_csv(self.edge_out_path, index=None)
+        df_edges.fillna('NA').to_csv(self.edge_out_path, index=None)
 
+        for line in self.node_lines:
+          for key, value in line.items():
+            if type(value) is str and value == '':
+              line[key] = None
         df_nodes = pd.DataFrame(self.node_lines)
         df_nodes = df_nodes[self.node_columns]
-        df_nodes.to_csv(self.node_out_path, index=None)
+        df_nodes.fillna('NA').to_csv(self.node_out_path, index=None)
 
     def handle_statement(self, s, start_id):
         # if a statement has multiple refs, it will return multiple lines


### PR DESCRIPTION
I added a fix in the write_out() function to fill empty string fields, which were '', with 'NA' string, as required format for Neo4j. This enables Neo4j Browser to display all resource attributes whether are filled or not.