### PR TITLE
Add fix in create_initial_props() to deal with 'exactMatch' prop.

### DIFF
--- a/neo4j_to_wd.py
+++ b/neo4j_to_wd.py
@@ -53,10 +53,12 @@ class Bot:
 
     def create_initial_props(self):
         # properties we need regardless of whats in the edges file
-        self.create_property("exact match", "v1", "string", "http://www.w3.org/2004/02/skos/core#exactMatch",
+        self.create_property("exact match", "", "string", "http://www.w3.org/2004/02/skos/core#exactMatch",
                              "skos:exactMatch")
-        self.create_property("exact match", "v2", "string", "http://www.w3.org/2004/02/skos/core#skos_exactMatch",
-                             "skos:exactMatch")
+        #self.create_property("exact match", "v1", "string", "http://www.w3.org/2004/02/skos/core#exactMatch",
+        #                     "skos:exactMatch")
+        #self.create_property("exact match", "v2", "string", "http://www.w3.org/2004/02/skos/core#skos_exactMatch",
+        #                     "skos:exactMatch")
         self.create_property("reference uri", "", "url", "http://www.wikidata.org/entity/P854", "reference_uri")
         self.create_property("reference supporting text", "", "string", "http://reference_supporting_text",
                              "ref_supp_text")


### PR DESCRIPTION
 i fixed the population problem from Neo4j to Wikibase. I changed the create_initial_props() function in a way that now it only creates one property as string type to deal with 'skos:exactMatch' property. Otherwise, wdi module does not allow to populate the instance due to redundant properties. Beforehand, i changed the skos:exactMatch uri records to the correct one in the input Neo4j CSV statement file.